### PR TITLE
Add msig as enrich db option

### DIFF
--- a/R/GeneTonic-extras.R
+++ b/R/GeneTonic-extras.R
@@ -6,7 +6,7 @@
 #' the components of the list should have.
 #' For backwards compatibility, the `GeneTonic_list` function is still provided
 #' as a synonim, and will likely be deprecated in the upcoming release cycles.
-#' 
+#'
 #' @param dds A `DESeqDataSet` object, normally obtained after running your data
 #' through the `DESeq2` framework.
 #' @param res_de A `DESeqResults` object. As for the `dds` parameter, this is
@@ -193,12 +193,12 @@ describe_gtl <- function(gtl) {
 #' go_2_html("GO:0043368")
 go_2_html <- function(go_id,
                       res_enrich = NULL) {
-  .Deprecated(old = "go_2_html", new = "mosdef::go_to_html", 
+  .Deprecated(old = "go_2_html", new = "mosdef::go_to_html",
               msg = paste0(
                 "Please use `mosdef::go_to_html()` in replacement of the `go_2_html()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::go_to_html()` to see the details on how to use it"))
-  
+
   mycontent <- mosdef::go_to_html(go_id = go_id,
                                   res_enrich = res_enrich)
   return(mycontent)
@@ -211,12 +211,12 @@ go_2_html <- function(go_id,
 #' @return HTML for an action button
 #' @noRd
 .link2amigo <- function(val) {
-  .Deprecated(old = ".link2amigo", new = "mosdef::create_link_GO", 
+  .Deprecated(old = ".link2amigo", new = "mosdef::create_link_GO",
               msg = paste0(
                 "Please use `mosdef::create_link_GO()` in replacement of the `.link2amigo()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::create_link_GO()` to see the details on how to use it"))
-  
+
   mosdef::create_link_GO(val = val)
 }
 
@@ -243,15 +243,15 @@ go_2_html <- function(go_id,
 #' geneinfo_2_html("Pf4")
 geneinfo_2_html <- function(gene_id,
                             res_de = NULL) {
-  .Deprecated(old = "geneinfo_2_html", new = "mosdef::geneinfo_to_html", 
+  .Deprecated(old = "geneinfo_2_html", new = "mosdef::geneinfo_to_html",
               msg = paste0(
                 "Please use `mosdef::geneinfo_to_html()` in replacement of the `geneinfo_2_html()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::geneinfo_to_html()` to see the details on how to use it"))
-  
+
   mycontent <- mosdef::geneinfo_to_html(gene_id = gene_id,
                                         res_de = res_de)
-  
+
   return(mycontent)
 }
 
@@ -262,12 +262,12 @@ geneinfo_2_html <- function(gene_id,
 #' @return HTML for an action button
 #' @noRd
 .link2ncbi <- function(val) {
-  .Deprecated(old = ".link2ncbi", new = "mosdef::create_link_NCBI", 
+  .Deprecated(old = ".link2ncbi", new = "mosdef::create_link_NCBI",
               msg = paste0(
                 "Please use `mosdef::create_link_NCBI()` in replacement of the `.link2ncbi()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::create_link_NCBI()` to see the details on how to use it"))
-  
+
   mosdef::create_link_NCBI(val = val)
 }
 
@@ -278,12 +278,12 @@ geneinfo_2_html <- function(gene_id,
 #' @return HTML for an action button
 #' @noRd
 .link2genecards <- function(val) {
-  .Deprecated(old = ".link2genecards", new = "mosdef::create_link_GeneCards", 
+  .Deprecated(old = ".link2genecards", new = "mosdef::create_link_GeneCards",
               msg = paste0(
                 "Please use `mosdef::create_link_GeneCards()` in replacement of the `.link2genecards()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::create_link_GeneCards()` to see the details on how to use it"))
-  
+
   mosdef::create_link_GeneCards(val = val)
 }
 
@@ -294,12 +294,12 @@ geneinfo_2_html <- function(gene_id,
 #' @return HTML for an action button
 #' @noRd
 .link2gtex <- function(val) {
-  .Deprecated(old = ".link2gtex", new = "mosdef::create_link_GTEX", 
+  .Deprecated(old = ".link2gtex", new = "mosdef::create_link_GTEX",
               msg = paste0(
                 "Please use `mosdef::create_link_GTEX()` in replacement of the `.link2gtex()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::create_link_GTEX()` to see the details on how to use it"))
-  
+
   mosdef::create_link_GTEX(val = val)
 }
 
@@ -463,18 +463,18 @@ overlap_jaccard_index <- function(x, y) {
 styleColorBar_divergent <- function(data,
                                     color_pos,
                                     color_neg) {
-  .Deprecated(old = "styleColorBar_divergent", new = "mosdef::styleColorBar_divergent", 
+  .Deprecated(old = "styleColorBar_divergent", new = "mosdef::styleColorBar_divergent",
               msg = paste0(
                 "Please use `mosdef::styleColorBar_divergent()` in replacement of the `styleColorBar_divergent()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::styleColorBar_divergent()` to see the details on how to use it"))
-  
+
   code_ret <- mosdef::styleColorBar_divergent(
     data = data,
     color_pos = color_pos,
     color_neg = color_neg
   )
-  
+
   return(code_ret)
 }
 
@@ -511,13 +511,13 @@ styleColorBar_divergent <- function(data,
 #' )(50)
 #' plot(b, col = map2color(b, pal2), pch = 20, cex = 3)
 map2color <- function(x, pal, symmetric = TRUE, limits = NULL) {
-  .Deprecated(old = "map2color", new = "mosdef::map_to_color", 
+  .Deprecated(old = "map2color", new = "mosdef::map_to_color",
               msg = paste0(
                 "Please use `mosdef::map_to_color()` in replacement of the `map2color()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::map_to_color()` to see the details on how to use it"))
-  
-  pal_ret <- map_to_color(x = x, 
+
+  pal_ret <- map_to_color(x = x,
                           pal = pal,
                           symmetric = symmetric,
                           limits = limits)
@@ -578,12 +578,12 @@ check_colors <- function(x) {
 #' res_df <- mosdef::deresult_to_df(res_macrophage_IFNg_vs_naive)
 #' head(res_df)
 deseqresult2df <- function(res_de, FDR = NULL) {
-  .Deprecated(old = "deseqresult2df", new = "mosdef::deresult_to_df", 
+  .Deprecated(old = "deseqresult2df", new = "mosdef::deresult_to_df",
               msg = paste0(
                 "Please use `mosdef::deresult_to_df()` in replacement of the `deseqresult2df()` function, ",
                 "originally located in the GeneTonic package. \nCheck the manual page for ",
                 "`?mosdef::deresult_to_df()` to see the details on how to use it"))
-  
+
   df <- mosdef::deresult_to_df(res_de = res_de,
                                FDR = FDR)
   return(df)
@@ -645,6 +645,26 @@ editor_to_vector_sanitized <- function(txt) {
   sub(" +$", "", rn)
 }
 
+#' convert limma results to dataframe with DESeq column names
+#'
+#' @param res_de limma toptable results
+#' @param FDR false discovery rate cutoff
+#'
+#' @return dataframe with deseq-like result column names
+#' @export
+#'
+#' @examples TODO
+limma2df<-function(res_de,FDR=NULL){
+  res<- cbind(rownames(res_de),res_de)
+  names(res)[c(1,2,6)]=c('id','log2FoldChange','padj')
+  res$id=as.character(res$id)
+  res=res[order(res$padj),]
+  if(!is.null(FDR)){
+    res=res[!is.na(res$padj) & res$padj<=FDR,]
+  }
+  return(res)
+}
+
 GeneTonic_footer <- fluidRow(
   column(
     width = 1,
@@ -668,6 +688,8 @@ GeneTonic_footer <- fluidRow(
     tags$a(href = "https://github.com/federicomarini/GeneTonic", "GitHub")
   )
 )
+
+
 
 # Shiny resource paths ----------------------------------------------------
 

--- a/R/enhance_table.R
+++ b/R/enhance_table.R
@@ -19,7 +19,7 @@
 #' available in `res_enrich`. Lists the gene sets to be displayed.
 #' @param chars_limit Integer, number of characters to be displayed for each
 #' geneset name.
-#' @param plot_style Character value, one of "point" or "ridgeline". Defines the 
+#' @param plot_style Character value, one of "point" or "ridgeline". Defines the
 #' style of the plot to summarize visually the table.
 #' @param ridge_color Character value, one of "gs_id" or "gs_score", controls the
 #' fill color of the ridge lines. If selecting "gs_score", the `z_score` column
@@ -69,7 +69,7 @@
 #'   anno_df,
 #'   n_gs = 10
 #' )
-#' 
+#'
 #' # using the ridge line as a style, also coloring by the Z score
 #' res_enrich_withscores <- get_aggrscores(
 #'   res_enrich,
@@ -79,7 +79,7 @@
 #' enhance_table(res_enrich_withscores,
 #'   res_de,
 #'   anno_df,
-#'   n_gs = 10, 
+#'   n_gs = 10,
 #'   plot_style = "ridgeline",
 #'   ridge_color = "gs_score"
 #' )
@@ -100,10 +100,10 @@ enhance_table <- function(res_enrich,
     res_enrich <- gtl$res_enrich
     annotation_obj <- gtl$annotation_obj
   }
-  
+
   plot_style <- match.arg(plot_style, c("point", "ridgeline"))
   ridge_color <- match.arg(ridge_color, c("gs_id", "gs_score"))
-  
+
   n_gs <- min(n_gs, nrow(res_enrich))
 
   gs_to_use <- unique(
@@ -118,7 +118,7 @@ enhance_table <- function(res_enrich,
     genes_thisset <- unlist(strsplit(genes_thisset, ","))
 
     genesid_thisset <- annotation_obj$gene_id[match(genes_thisset, annotation_obj$gene_name)]
-    
+
     # removing the genes not finding a match in the annotation
     no_anno_match <- is.na(genesid_thisset)
     genes_thisset_anno <- genes_thisset[!no_anno_match]
@@ -131,7 +131,7 @@ enhance_table <- function(res_enrich,
               " the gene(s) named: ",
               paste0(genes_thisset[no_anno_match], collapse = ", "))
     }
-    
+
     res_thissubset <- res_de[genesid_thisset_anno, ]
 
     res_thissubset <- as.data.frame(res_thissubset)
@@ -145,8 +145,11 @@ enhance_table <- function(res_enrich,
   gs_fulllist <- do.call(rbind, gs_fulllist)
   # message(dim(gs_fulllist)[1])
 
+  if(class(res_de)=="DESeqResults"){
   this_contrast <- (sub(".*p-value: (.*)", "\\1", mcols(res_de, use.names = TRUE)["pvalue", "description"]))
-
+  } else{
+    this_contrast <- ""
+  }
   # to have first rows viewed on top
   gs_fulllist <- gs_fulllist[rev(seq_len(nrow(gs_fulllist))), ]
   gs_fulllist$gs_desc <- factor(gs_fulllist$gs_desc, levels = rev(levels(gs_fulllist$gs_desc)))
@@ -157,7 +160,7 @@ enhance_table <- function(res_enrich,
     substr(as.character(unique(gs_fulllist$gs_desc)), 1, chars_limit),
     " | ", unique(gs_fulllist$gs_id)
   )
-  
+
   if (plot_style == "point") {
     p <- ggplot(
       gs_fulllist, aes(
@@ -177,14 +180,14 @@ enhance_table <- function(res_enrich,
         labels = gs_labels
       ) +
       labs(x = "log2 Fold Change")
-    
+
   } else if (plot_style == "ridgeline") {
-    
+
     if (ridge_color == "gs_score" & is.null(res_enrich$z_score)) {
       message("Fallback to plotting the ridgelines according to geneset id (Z score required)")
       ridge_color <- "gs_id"
-    }  
-    
+    }
+
     if (ridge_color == "gs_score") {
       gs_fulllist$gs_zscore <- res_enrich$z_score[match(gs_fulllist$gs_id, res_enrich$gs_id)]
       p <- ggplot(
@@ -194,8 +197,8 @@ enhance_table <- function(res_enrich,
           fill = .data$gs_zscore
         )
       ) +
-        scale_x_continuous(limits = c(-max_lfc, max_lfc)) + 
-        scale_fill_gradient2(low = "#313695", mid = "#FFFFE5", high = "#A50026") + 
+        scale_x_continuous(limits = c(-max_lfc, max_lfc)) +
+        scale_fill_gradient2(low = "#313695", mid = "#FFFFE5", high = "#A50026") +
         ggridges::geom_density_ridges(
           aes(group = .data$gs_id),
           point_color = "#00000066",
@@ -218,7 +221,7 @@ enhance_table <- function(res_enrich,
           fill = .data$gs_id
         )
       ) +
-        scale_x_continuous(limits = c(-max_lfc, max_lfc)) + 
+        scale_x_continuous(limits = c(-max_lfc, max_lfc)) +
         ggridges::geom_density_ridges(
           aes(group = .data$gs_id),
           point_color = "#00000066",

--- a/R/ggs_graph.R
+++ b/R/ggs_graph.R
@@ -124,6 +124,9 @@ ggs_graph <- function(res_enrich,
 
   enriched_gsids <- res_enrich[["gs_id"]]
   enriched_gsnames <- res_enrich[["gs_description"]]
+  if("gs_fulldesc" %in% colnames(res_enrich)){
+    enriched_gsdescs <- res_enrich[['gs_fulldesc']]
+  } else{
   enriched_gsdescs <- vapply(
     enriched_gsids,
     function(arg) {
@@ -133,7 +136,7 @@ ggs_graph <- function(res_enrich,
       )
     },
     character(1)
-  )
+  )}
 
   gs_to_use <- unique(
     c(
@@ -193,9 +196,19 @@ ggs_graph <- function(res_enrich,
 
     # title for tooltips
     V(g)$title <- NA
+    #not sure best way to test for GO vs other database - also link only works if msig
+    #could have link as an optional column like gs_fulldesc in res_enrich?
+    if("gs_fulldesc" %in% colnames(res_enrich)){
+      link_gs<- sprintf('<a href="https://www.gsea-msigdb.org/gsea/msigdb/human/geneset/%s.html" target="_blank">%s</a>',
+                       enriched_gsnames[nodeIDs_gs], enriched_gsids[nodeIDs_gs])
+    } else{
+      link_gs <- sprintf('<a href="http://amigo.geneontology.org/amigo/term/%s" target="_blank">%s</a>',
+                        enriched_gsids[nodeIDs_gs], enriched_gsids[nodeIDs_gs])
+    }
+
     V(g)$title[nodeIDs_gs] <- paste0(
       "<h4>",
-      sprintf('<a href="http://amigo.geneontology.org/amigo/term/%s" target="_blank">%s</a>', enriched_gsids[nodeIDs_gs], enriched_gsids[nodeIDs_gs]), "</h4><br>",
+      link_gs, "</h4><br>",
       V(g)$name[nodeIDs_gs], "<br><br>",
       sapply(enriched_gsdescs[nodeIDs_gs],
              function(x) paste0(strwrap(x, 50), collapse='<br>'))
@@ -444,7 +457,7 @@ ggs_backbone <- function(res_enrich,
                                                 limits = range(na.omit(col_var)))
         V(bbgraph)$color.hover <- mosdef::map_to_color(col_var, mypal_hover, symmetric = TRUE,
                                             limits = range(na.omit(col_var)))
-        
+
         V(bbgraph)$color.background[is.na(V(bbgraph)$color.background)] <- "lightgrey"
         V(bbgraph)$color.highlight[is.na(V(bbgraph)$color.highlight)] <- "lightgrey"
         V(bbgraph)$color.hover[is.na(V(bbgraph)$color.hover)] <- "lightgrey"
@@ -469,17 +482,17 @@ ggs_backbone <- function(res_enrich,
           colorRampPalette(RColorBrewer::brewer.pal(name = "RdYlBu", 11))(50), 1
         ))
 
-        V(bbgraph)$color.background <- mosdef::map_to_color(col_var, mypal, 
+        V(bbgraph)$color.background <- mosdef::map_to_color(col_var, mypal,
                                                  limits = range(na.omit(col_var)))
-        V(bbgraph)$color.highlight <- mosdef::map_to_color(col_var, mypal_select, 
+        V(bbgraph)$color.highlight <- mosdef::map_to_color(col_var, mypal_select,
                                                 limits = range(na.omit(col_var)))
-        V(bbgraph)$color.hover <- mosdef::map_to_color(col_var, mypal_hover, 
+        V(bbgraph)$color.hover <- mosdef::map_to_color(col_var, mypal_hover,
                                             limits = range(na.omit(col_var)))
 
         V(bbgraph)$color.background[is.na(V(bbgraph)$color.background)] <- "lightgrey"
         V(bbgraph)$color.highlight[is.na(V(bbgraph)$color.highlight)] <- "lightgrey"
         V(bbgraph)$color.hover[is.na(V(bbgraph)$color.hover)] <- "lightgrey"
-        
+
         V(bbgraph)$color.border <- "black"
 
         # additional specification of edge colors

--- a/R/gs_shaker.R
+++ b/R/gs_shaker.R
@@ -124,8 +124,8 @@ shake_enrichResult <- function(obj) {
 #' # res object
 #' data(res_de_macrophage, package = "GeneTonic")
 #' sorted_genes <- sort(
-#'   setNames(res_macrophage_IFNg_vs_naive$log2FoldChange, 
-#'            res_macrophage_IFNg_vs_naive$SYMBOL), 
+#'   setNames(res_macrophage_IFNg_vs_naive$log2FoldChange,
+#'            res_macrophage_IFNg_vs_naive$SYMBOL),
 #'   decreasing = TRUE
 #' )
 #' \dontrun{
@@ -155,23 +155,23 @@ shake_gsenrichResult <- function(obj) {
   if (!is(obj, "gseaResult")) {
     stop("Provided object must be of class `gseaResult`")
   }
-  
+
   if (is.null(obj@result$core_enrichment)) {
     stop(
       "You are providing an object where the `core_enrichment` is not specified, ",
       "this is required for running GeneTonic properly."
     )
   }
-  
+
   message(
     "Using the content of the 'core_enrichment' column to generate the 'gs_genes' for GeneTonic...",
     " If you have that information available directly, please adjust the content accordingly.",
     "\n\nUsing the set of the 'core_enrichment' size to compute the 'gs_de_count'"
   )
-  
+
   message("Found ", nrow(obj@result), " gene sets in `gseaResult` object, of which ", nrow(as.data.frame(obj)), " are significant.")
   message("Converting for usage in GeneTonic...")
-  
+
   fullresults <- obj@result
 
   mydf <- data.frame(
@@ -189,7 +189,7 @@ shake_gsenrichResult <- function(obj) {
   )
 
   rownames(mydf) <- mydf$gs_id
-  
+
   return(mydf)
 }
 
@@ -601,4 +601,46 @@ shake_fgseaResult <- function(fgsea_output) {
 
 
   return(mydf)
+}
+
+#' prepare gsva results (after limma DE) for downstream genetonic
+#'
+#' @param obj limma toptable with gsva as input
+#' @param res_de DE dataframe with ensembl ids
+#' @param m_df annotations from msigdbr
+#' @param gset genesets from gsva results (geneSets(gsva_res))
+#' @param anno_df dataframe with ensembl to symbol mapping
+#'
+#' @return dataframe with standardized names for downstream genetonic
+#' @export
+#'
+#' @examples TODO
+shake_gsvaResult<-function(obj,res_de,m_df,gset,anno_df){
+  m_dfu=m_df[!duplicated(m_df$gs_name),c("gs_name","gs_id","gs_description")]
+  m_dfu=m_dfu[match(rownames(obj),m_dfu$gs_name),]
+  anno_df2=anno_df[match(res_de$id,anno_df$gene_id),]
+
+  gset2=gset[match(m_dfu$gs_name,names(gset))]
+  gcomb=sapply(gset2,function(x) paste(anno_df2$gene_name[anno_df2$gene_name %in% x],collapse=','))
+  gbg=sapply(gset2,function(x) length(x))
+  gsde=sapply(gset2,function(x) sum(anno_df2$gene_name %in% x))
+
+
+  mydf <- data.frame(
+    gs_id = m_dfu$gs_id,
+    gs_description = m_dfu$gs_name,
+    gs_fulldesc=m_dfu$gs_description,
+    gs_pvalue = obj$P.Value,
+    gs_genes = gcomb,
+    gs_de_count = gsde,
+    gs_bg_count = gbg,
+    gs_logFC = obj$logFC,
+    gs_p.adjust = obj$adj.P.Val,
+    stringsAsFactors = FALSE
+  )
+
+  rownames(mydf) <- mydf$gs_id
+
+  return(mydf)
+
 }


### PR DESCRIPTION
Hi,
here is my initial idea for letting msig (or in principle other databases) be the database used in shake functions, and later downstream in ggs_graph, etc. 

To avoid breaking changes, I've made the following changes
1. enhance_table checks if de object is deseq. If not, don't have a contrast in title
2. shake_gsvaResult() adds the msig full description as a column (gs_fulldesc)
3.  In ggs_graph, use gs_fulldesc if present instead of pulling from GOTERM
4.  in ggs_graph, if gs_fulldesc present, change link in tool tip to link to msig.

What are your thoughts?  My focus was on the enhance_table and ggs_graph for my immediate research needs, but if other functions don't rely on goterm descriptions I think they will work as normal.

I'll work on an example limma/gsva prep on the macrophage data if this seems like a worthwhile addition.